### PR TITLE
Let RC discussion import as normal channels with full names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Export supports the following entities:
    It is used for id mapping, without it MM won't import the users and throw an error.  
    Before migrating to MM, ensure you have Gitlab integration enabled in MM and all users are present in Gitlab.
 
-4. If you used RocketChat discussions, they will migrate in separate channels with random names. 
-   You can merge discussions in parent channel with `mergeDiscussionIntoParent`
-5. Global channel in Rocket Chat us **General** and in Mattermost - **Town Square**. 
+4. If you used RocketChat discussions, they will migrate in separate channels with their full names. 
+   You can instead choose to merge discussions into their parent channel with `mergeDiscussionIntoParent`
+5. Global channel in Rocket Chat uses **General** and in Mattermost - **Town Square**. 
    To have only 1 global channel, the configuration provides default example in `channels.map`. 
    You can specify migration for other channels as well.
 6. Run migrate script with `npm run start:rocketchat`

--- a/lib/rocketchat/channels.js
+++ b/lib/rocketchat/channels.js
@@ -25,12 +25,21 @@ module.exports = async function (context) {
       log.info(`... skipping channel ${result._id} to merge discussion into parent ${result.prid}`)
       continue;
     }
+    
+    // Get discussion full name
+    if (result.prid){
+      _name = slug(_.toLower(result.fname));
+      _display_name = result.fname;
+    } else {
+      _name = slug(_.toLower(result.name));
+      _display_name = result.name;
+    }
 
     // Define the channel and add it to the context
     let channel = channels[result._id] = {
       team: context.values.team.name,
-      name: slug(_.toLower(result.name)),
-      display_name: result.name,
+      name: _name,
+      display_name: _display_name,
       header: result.topic,
       purpose: result.description,
       type: result.t === 'p' ? 'P' : 'O'


### PR DESCRIPTION
This PR allows the export and import of rocketchat discussions as new regular channels in Mattermost with their full original names. Users can still also choose to merge discussions into their parent channel instead.