### PR TITLE
catch errors in exporting posts and continue

### DIFF
--- a/lib/rocketchat/posts.js
+++ b/lib/rocketchat/posts.js
@@ -21,9 +21,13 @@ module.exports = async function (context) {
   while (await cursor.hasNext()) {
     const result = await cursor.next()
     let posts = await collectPostData(context, result, memReplyIds, false)
-    posts.forEach(function(post) {
-      context.output.write(post.isDirect ? Factory.directPost(post) : Factory.post(post))
-    })
+    try{
+      posts.forEach(function(post) {
+        context.output.write(post.isDirect ? Factory.directPost(post) : Factory.post(post))
+      })
+    } catch (error) {
+      console.error(error);
+    }
     // Log progress periodically
     written += posts.length
     if (written % 1000 == 0) {


### PR DESCRIPTION
This PR lets an export process continue if there is an error in importing a post rather than bombing out the whole export for one malformed post.